### PR TITLE
feat: 알림 SSE 기능 추가

### DIFF
--- a/internal/api/handler/sse.go
+++ b/internal/api/handler/sse.go
@@ -1,0 +1,92 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+	"torchi/internal/domain/sse"
+	"torchi/internal/pkg/log"
+	"torchi/internal/pkg/token"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type SSEHandler struct {
+	log    *log.Logger
+	broker *sse.Broker
+}
+
+func NewSSEHandler(log *log.Logger, broker *sse.Broker) *SSEHandler {
+	return &SSEHandler{log: log, broker: broker}
+}
+
+func (h *SSEHandler) Routes() chi.Router {
+	r := chi.NewRouter()
+	r.Get("/notifications", h.Stream)
+	return r
+}
+func (h *SSEHandler) Stream(w http.ResponseWriter, r *http.Request) {
+	userClaim, err := token.UserFromContext(r.Context())
+	if err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	ch := h.broker.Subscribe(userClaim.UserID)
+	defer func() {
+		h.broker.Unsubscribe(userClaim.UserID, ch)
+	}()
+
+	// send 헬퍼 - 실패 시 false 반환
+	send := func(format string, args ...any) bool {
+		_, err := fmt.Fprintf(w, format, args...)
+		if err != nil {
+			h.log.Info("client disconnected while writing", "userID", userClaim.UserID)
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+
+	if !send("event: connected\ndata: {}\n\n") {
+		return
+	}
+
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			h.log.Info("context done")
+			return
+		case <-h.broker.Done():
+			return
+		case <-ticker.C:
+			if !send(": heartbeat\n\n") {
+				return
+			}
+		case event, ok := <-ch:
+			if !ok {
+				return
+			}
+			data, err := json.Marshal(event.Data)
+			if err != nil {
+				h.log.Error("sse marshal error", "err", err)
+				continue
+			}
+			if !send("event: %s\ndata: %s\n\n", event.Event, string(data)) {
+				return
+			}
+		}
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -18,6 +18,7 @@ func NewRouter(
 	endpointHandler *handler.EndpointHandler,
 	apiHandler *handler.ApiHandler,
 	notiHandler *handler.NotiHandler,
+	sseHandler *handler.SSEHandler,
 
 	tokenProvider *token.TokenProvider,
 	env config.Env,
@@ -41,6 +42,7 @@ func NewRouter(
 			r.Mount("/users", userHandler.Routes())
 			r.Mount("/endpoints", endpointHandler.Routes())
 			r.Mount("/notifications", notiHandler.Routes())
+			r.Mount("/sse", sseHandler.Routes())
 		})
 	})
 
@@ -54,6 +56,7 @@ var routeModule = fx.Module("router",
 		handler.NewUserHandler,
 		handler.NewEndpointHandler,
 		handler.NewNotiHandler,
+		handler.NewSSEHandler,
 
 		// API
 		handler.NewApiHandler,

--- a/internal/core/app.go
+++ b/internal/core/app.go
@@ -36,6 +36,7 @@ func RunServer(opt ...fx.Option) {
 		fx.Invoke(run),
 	)
 	app := fx.New(opts)
+	slog.SetDefault(logger.Logger)
 
 	ctx := context.Background()
 	if err := app.Start(ctx); err != nil {

--- a/internal/domain/module.go
+++ b/internal/domain/module.go
@@ -5,6 +5,7 @@ import (
 	"torchi/internal/domain/endpoint"
 	"torchi/internal/domain/notifications"
 	"torchi/internal/domain/push"
+	"torchi/internal/domain/sse"
 	"torchi/internal/domain/token"
 	"torchi/internal/domain/user"
 
@@ -19,4 +20,5 @@ var Module = fx.Options(
 	token.Module,
 	endpoint.Module,
 	notifications.Module,
+	sse.Module,
 )

--- a/internal/domain/notifications/repository.go
+++ b/internal/domain/notifications/repository.go
@@ -111,6 +111,7 @@ func (r *notiRepository) Create(ctx context.Context, noti Noti) (Noti, error) {
 		ID:         createdRow.ID,
 		EndpointID: createdRow.EndpointID,
 		Body:       createdRow.Body,
+		Actions:    createdRow.Actions,
 	}
 	return entity, err
 }

--- a/internal/domain/push/service.go
+++ b/internal/domain/push/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"torchi/internal/domain/endpoint"
 	"torchi/internal/domain/notifications"
+	"torchi/internal/domain/sse"
 	"torchi/internal/domain/token"
 	"torchi/internal/pkg/config"
 	"torchi/internal/pkg/log"
@@ -22,6 +23,7 @@ type PushService struct {
 	tokenService    *token.TokenService
 	endpointService *endpoint.EndpointService
 	notiService     *notifications.NotiService
+	sseBroker       *sse.Broker
 
 	waitMap *WaitMap
 }
@@ -33,6 +35,7 @@ func NewPushService(
 	tokenService *token.TokenService,
 	endpointService *endpoint.EndpointService,
 	notiService *notifications.NotiService,
+	sseBroker *sse.Broker,
 ) *PushService {
 	return &PushService{
 		log:             log,
@@ -40,6 +43,7 @@ func NewPushService(
 		tokenService:    tokenService,
 		endpointService: endpointService,
 		notiService:     notiService,
+		sseBroker:       sseBroker,
 		waitMap:         NewWaitMap(), // TODO: FX로 주입
 	}
 }
@@ -112,6 +116,8 @@ func (s *PushService) Push(ctx context.Context, endpointToken string, message st
 		Body:               message,
 		NotificationEnable: endpoint.NotificationEnable,
 	})
+
+	s.publishSSE(userID, noti, endpoint.Name)
 
 	if !endpoint.NotificationEnable {
 		return 0, err
@@ -217,6 +223,8 @@ func (s *PushService) PushAndWait(ctx context.Context, endpointToken string, mes
 		return "", err
 	}
 
+	s.publishSSE(userID, noti, endpoint.Name)
+
 	if endpoint.NotificationEnable {
 		for _, token := range tokens {
 			if err := s.pushNotification(token, endpoint.Name, message); err != nil {
@@ -263,4 +271,22 @@ func (s *PushService) React(ctx context.Context, notiID uuid.UUID, reaction stri
 	}
 
 	return nil
+}
+
+func (s *PushService) publishSSE(userID uuid.UUID, noti notifications.Noti, endpointName string) {
+	s.sseBroker.Publish(userID, sse.SSEEvent{
+		Event: "notification",
+		Data: map[string]interface{}{
+			"id":            noti.ID,
+			"endpoint_name": endpointName,
+			"body":          noti.Body,
+			"is_read":       false,
+			"created_at":    noti.CreatedAt,
+			"mute":          noti.IsMute(),
+			"actions":       noti.Actions,
+			"reaction":      noti.Reaction,
+			"reaction_at":   noti.ReactionAt,
+			"status":        string(noti.Status),
+		},
+	})
 }

--- a/internal/domain/sse/broker.go
+++ b/internal/domain/sse/broker.go
@@ -1,0 +1,94 @@
+package sse
+
+import (
+	"log/slog"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type SSEEvent struct {
+	Event string      // "notification", "heartbeat" 등
+	Data  interface{} // JSON 직렬화될 데이터
+}
+
+type Broker struct {
+	mu      sync.RWMutex
+	clients map[uuid.UUID]map[chan SSEEvent]struct{}
+	done    chan struct{}
+}
+
+func NewBroker() *Broker {
+	return &Broker{
+		clients: make(map[uuid.UUID]map[chan SSEEvent]struct{}),
+		done:    make(chan struct{}),
+	}
+}
+
+// Done, 브로커가 종료될 때 닫히는 채널을 반환합니다.
+func (b *Broker) Done() <-chan struct{} {
+	return b.done
+}
+
+// Shutdown closes all client channels and signals done.
+func (b *Broker) Shutdown() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for userID, set := range b.clients {
+		for ch := range set {
+			close(ch)
+		}
+		delete(b.clients, userID)
+	}
+
+	close(b.done)
+}
+
+func (b *Broker) Subscribe(userID uuid.UUID) chan SSEEvent {
+	ch := make(chan SSEEvent, 16)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.clients[userID] == nil {
+		b.clients[userID] = make(map[chan SSEEvent]struct{})
+	}
+	b.clients[userID][ch] = struct{}{}
+	slog.Debug("subscribe", "clients", b.clients[userID])
+
+	return ch
+}
+
+func (b *Broker) Unsubscribe(userID uuid.UUID, ch chan SSEEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	slog.Debug("unsubscribe", "clients", b.clients[userID])
+
+	if set, ok := b.clients[userID]; ok {
+		delete(set, ch)
+		close(ch)
+		if len(set) == 0 {
+			delete(b.clients, userID)
+		}
+	}
+}
+
+func (b *Broker) Publish(userID uuid.UUID, event SSEEvent) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	set, ok := b.clients[userID]
+	if !ok {
+		return
+	}
+
+	for ch := range set {
+		// non-blocking send
+		select {
+		case ch <- event:
+		default: // 버퍼가 가득 차있을 때 블락되는 걸 방지
+		}
+	}
+}

--- a/internal/domain/sse/module.go
+++ b/internal/domain/sse/module.go
@@ -1,0 +1,19 @@
+package sse
+
+import (
+	"context"
+
+	"go.uber.org/fx"
+)
+
+var Module = fx.Options(
+	fx.Provide(NewBroker),
+	fx.Invoke(func(lc fx.Lifecycle, broker *Broker) {
+		lc.Append(fx.Hook{
+			OnStop: func(ctx context.Context) error {
+				broker.Shutdown()
+				return nil
+			},
+		})
+	}),
+)

--- a/internal/pkg/log/logger.go
+++ b/internal/pkg/log/logger.go
@@ -42,6 +42,7 @@ func NewLogger(env config.Env) *Logger {
 	}
 
 	rawLogger := slog.New(handler)
+
 	return &Logger{Logger: rawLogger}
 }
 


### PR DESCRIPTION


## Summary
  - 알림 발생 시 SSE(Server-Sent Events)를 통해 클라이언트에 실시간 푸시하는 기능 추가
  - 유저별 SSE 구독/해제를 관리하는 in-memory Broker 구현
  - Push 발생 시 FCM 알림과 함께 SSE 이벤트를 동시에 발행
  - `slog.SetDefault` 설정으로 글로벌 로거에 커스텀 핸들러 적용

  ## Changes
  | 파일 | 변경 내용 |
  |------|-----------|
  | `internal/domain/sse/broker.go` | 유저별 채널 관리, Subscribe/Unsubscribe/Publish 구현 |
  | `internal/domain/sse/module.go` | fx 모듈 등록 및 Lifecycle hook으로 Shutdown 처리 |
  | `internal/api/handler/sse.go` | `GET /sse/notifications` SSE 스트림 핸들러 (heartbeat 30s) |
  | `internal/api/router.go` | SSE 핸들러 라우트 마운트 |
  | `internal/domain/push/service.go` | Push/PushAndWait 시 SSE 이벤트 발행 (`publishSSE`) |
  | `internal/domain/notifications/repository.go` | Create 응답에 누락된 `Actions` 필드 매핑 추가 |
  | `internal/core/app.go` | `slog.SetDefault` 호출로 글로벌 로거 설정 |

  ## SSE 프로토콜
  - **엔드포인트:** `GET /api/sse/notifications` (인증 필요)
  - **이벤트:** `connected` (연결 확인), `notification` (알림 데이터)
  - **Heartbeat:** 30초 간격 keep-alive
  - **버퍼:** 채널당 16개, non-blocking send로 slow client 대응

  ## Test plan
  - [ ] SSE 연결 후 `event: connected` 수신 확인
  - [ ] 알림 발생 시 `event: notification` 실시간 수신 확인
  - [ ] 클라이언트 연결 해제 시 리소스 정리 확인
  - [ ] 서버 종료 시 Broker Shutdown으로 모든 채널 정상 종료 확인
  - [ ] 글로벌 `slog` 호출이 커스텀 핸들러 포맷으로 출력되는지 확인

Closes #1 
