### PR TITLE
Fix/metrics: SSE 요청 매트릭 미들웨어에서 응답 블락되는 버그 수정

### DIFF
--- a/internal/api/middleware/metrics.go
+++ b/internal/api/middleware/metrics.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -43,8 +44,7 @@ func (m *Metrics) Middleware() func(http.Handler) http.Handler {
 			defer m.requestsInFlight.Dec()
 
 			start := time.Now()
-			ww := &responseWriter{ResponseWriter: w, status: http.StatusOK}
-
+			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 			next.ServeHTTP(ww, r)
 
 			path := chi.RouteContext(r.Context()).RoutePattern()
@@ -56,28 +56,8 @@ func (m *Metrics) Middleware() func(http.Handler) http.Handler {
 				return
 			}
 
-			m.requestsTotal.WithLabelValues(r.Method, path, strconv.Itoa(ww.status)).Inc()
+			m.requestsTotal.WithLabelValues(r.Method, path, strconv.Itoa(ww.Status())).Inc()
 			m.requestDuration.WithLabelValues(r.Method, path).Observe(time.Since(start).Seconds())
 		})
-	}
-}
-
-type responseWriter struct {
-	http.ResponseWriter
-	status      int
-	wroteHeader bool
-}
-
-func (rw *responseWriter) WriteHeader(code int) {
-	if !rw.wroteHeader {
-		rw.status = code
-		rw.wroteHeader = true
-		rw.ResponseWriter.WriteHeader(code)
-	}
-}
-
-func (rw *responseWriter) Flush() {
-	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
-		f.Flush()
 	}
 }

--- a/internal/api/middleware/metrics.go
+++ b/internal/api/middleware/metrics.go
@@ -96,3 +96,9 @@ func (rw *responseWriter) WriteHeader(code int) {
 		rw.ResponseWriter.WriteHeader(code)
 	}
 }
+
+func (rw *responseWriter) Flush() {
+	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}

--- a/internal/api/middleware/metrics.go
+++ b/internal/api/middleware/metrics.go
@@ -3,18 +3,12 @@ package middle
 import (
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
-
-// duration 측정에서 제외할 경로 suffix
-// - /ask: 사용자 반응 대기(최대 300s)로 레이턴시 왜곡
-// - /sse: 장기 연결로 레이턴시 의미 없음
-var skipDurationSuffixes = []string{"/ask", "/sse/notifications"}
 
 type Metrics struct {
 	requestsTotal    *prometheus.CounterVec
@@ -53,8 +47,6 @@ func (m *Metrics) Middleware() func(http.Handler) http.Handler {
 
 			next.ServeHTTP(ww, r)
 
-			// chi route pattern 사용으로 고카디널리티 방지
-			// e.g. /api/v1/push/{token} (실제 토큰 값 대신)
 			path := chi.RouteContext(r.Context()).RoutePattern()
 			if path == "" {
 				path = r.URL.Path
@@ -64,21 +56,8 @@ func (m *Metrics) Middleware() func(http.Handler) http.Handler {
 				return
 			}
 
-			status := strconv.Itoa(ww.status)
-			duration := time.Since(start).Seconds()
-
-			m.requestsTotal.WithLabelValues(r.Method, path, status).Inc()
-
-			skipDuration := false
-			for _, suffix := range skipDurationSuffixes {
-				if strings.HasSuffix(path, suffix) {
-					skipDuration = true
-					break
-				}
-			}
-			if !skipDuration {
-				m.requestDuration.WithLabelValues(r.Method, path).Observe(duration)
-			}
+			m.requestsTotal.WithLabelValues(r.Method, path, strconv.Itoa(ww.status)).Inc()
+			m.requestDuration.WithLabelValues(r.Method, path).Observe(time.Since(start).Seconds())
 		})
 	}
 }

--- a/internal/api/middleware/metrics_test.go
+++ b/internal/api/middleware/metrics_test.go
@@ -81,27 +81,15 @@ func TestDuration_NormalRoute(t *testing.T) {
 	}
 }
 
-func TestDuration_AskExcluded(t *testing.T) {
+func TestDuration_AskRoute(t *testing.T) {
 	m, reg := setup()
 	request(m, "/api/v1/push/{token}/ask", "/api/v1/push/abc123/ask")
 
-	if hasDurationSample(reg, "/api/v1/push/{token}/ask") {
-		t.Error("/ask는 duration이 집계되면 안 됨")
+	if !hasDurationSample(reg, "/api/v1/push/{token}/ask") {
+		t.Error("/ask도 duration이 집계되어야 함")
 	}
 	if !hasRequestCount(reg, "/api/v1/push/{token}/ask") {
-		t.Error("/ask도 requests_total은 집계되어야 함")
-	}
-}
-
-func TestDuration_SSEExcluded(t *testing.T) {
-	m, reg := setup()
-	request(m, "/api/sse/notifications", "/api/sse/notifications")
-
-	if hasDurationSample(reg, "/api/sse/notifications") {
-		t.Error("/sse/notifications는 duration이 집계되면 안 됨")
-	}
-	if !hasRequestCount(reg, "/api/sse/notifications") {
-		t.Error("/sse/notifications도 requests_total은 집계되어야 함")
+		t.Error("/ask도 requests_total이 집계되어야 함")
 	}
 }
 
@@ -113,4 +101,3 @@ func TestMetricsEndpointExcluded(t *testing.T) {
 		t.Error("/metrics 스크레이핑은 집계되면 안 됨")
 	}
 }
-


### PR DESCRIPTION
## Summary

직접 구현한 `responseWriter` 래퍼를 chi 내장 `middleware.NewWrapResponseWriter`로 교체했습니다.

## Problem

기존 `responseWriter`는 `http.ResponseWriter`만 래핑해서 `http.Flusher` 등 추가 인터페이스를 직접 위임해야 했고, 누락 시 SSE 같은 기능이 깨지는 문제가 있었습니다.

## Solution

chi를 이미 사용하고 있으므로 `middleware.NewWrapResponseWriter`로 교체했습니다.
`Flusher`, `Hijacker` 등 인터페이스를 내부적으로 처리해줘서 누락 위험이 없습니다.

## Changes
- `responseWriter` 구조체 및 `WriteHeader`, `Flush` 구현 삭제
- `middleware.NewWrapResponseWriter` 로 교체
- `ww.Status()`로 status 코드 참조